### PR TITLE
fix: Correct document ID in Docusaurus sidebar

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -32,7 +32,7 @@ const sidebars = {
       label: 'Core API',
       items: [
         'core-api/overview', // Points to docs/core-api/overview.md
-        'core-api/all-methods', // Points to docs/core-api/methods.md (via slug)
+        'core-api/methods', // Points to docs/core-api/methods.md (via slug)
       ],
     },
     // Example for a future "Guides" section


### PR DESCRIPTION
I changed 'core-api/all-methods' to 'core-api/methods' in website/sidebars.js to correctly reference the API methods document.

This fixes the Docusaurus build failure where the sidebar was pointing to a non-existent document ID.