### PR TITLE
fix: Update navbar to use correct Docusaurus sidebarId

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -89,9 +89,9 @@ const config = {
         items: [
           {
             type: 'docSidebar',
-            sidebarId: 'tutorialSidebar',
+            sidebarId: 'docsSidebar',
             position: 'left',
-            label: 'Tutorial',
+            label: 'Docs',
           },
           {to: '/blog', label: 'Blog', position: 'left'},
           {


### PR DESCRIPTION
I modified `website/docusaurus.config.js` to change the main documentation navbar item:
- Updated `sidebarId` from 'tutorialSidebar' to 'docsSidebar'.
- Updated `label` from 'Tutorial' to 'Docs'.

This fixes the Docusaurus build failure where the site was trying to render a non-existent sidebar named 'tutorialSidebar'.