### PR TITLE
Docs: Reorganize 'Use AIOHA' section and sidebar

### DIFF
--- a/website/docs/use-aioha.md
+++ b/website/docs/use-aioha.md
@@ -44,26 +44,6 @@ slug: /use-aioha
 
 ---
 
-### Get QR String
-`getQrString()`
-
-*   **Description:** Generates a QR code string, typically used for HiveAuth login flows.
-*   **Parameters:** None.
-*   **Returns:** `Future<String>`: A future that resolves to the QR code string.
-
----
-
-### Sign Message
-`signMessage(String message, String keyType)`
-
-*   **Description:** Signs an arbitrary message with the user's specified key type.
-*   **Parameters:**
-    *   `message` (`String`): The message to be signed.
-    *   `keyType` (`String`): The type of key to use for signing (e.g., "posting", "active").
-*   **Returns:** `Future<String>`: A future that resolves to the signed message or an error.
-
----
-
 ### User management
 
 ---
@@ -116,8 +96,6 @@ slug: /use-aioha
 ---
 
 ### Onchain Operations
-
-#### Social onchain operations
 
 ---
 
@@ -206,6 +184,30 @@ slug: /use-aioha
 
 ---
 
+### Helpers
+
+---
+
+### Get QR String
+`getQrString()`
+
+*   **Description:** Generates a QR code string, typically used for HiveAuth login flows.
+*   **Parameters:** None.
+*   **Returns:** `Future<String>`: A future that resolves to the QR code string.
+
+---
+
+### Sign Message
+`signMessage(String message, String keyType)`
+
+*   **Description:** Signs an arbitrary message with the user's specified key type.
+*   **Parameters:**
+    *   `message` (`String`): The message to be signed.
+    *   `keyType` (`String`): The type of key to use for signing (e.g., "posting", "active").
+*   **Returns:** `Future<String>`: A future that resolves to the signed message or an error.
+
+---
+
 ### Sign And Broadcast Tx
 `signAndBroadcastTx(dynamic operationRequest, String keyType)`
 
@@ -214,10 +216,6 @@ slug: /use-aioha
     *   `operationRequest` (`dynamic`): The operation or list of operations to be signed and broadcasted. The structure depends on the specific Hive operation.
     *   `keyType` (`String`): The type of key to use for signing (e.g., "posting", "active").
 *   **Returns:** `Future<dynamic>`: A future that resolves to the result of the broadcast, which could be a transaction ID or an error object.
-
----
-
-#### Active Key based operations
 
 ---
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -27,7 +27,20 @@ const sidebars = {
         'getting-started/basic-usage', // Points to docs/getting-started/basic-usage.md
       ],
     },
-    'use-aioha',
+    {
+      type: 'category',
+      label: 'Use AIOHA',
+      link: {
+        type: 'doc',
+        id: 'use-aioha',
+      },
+      items: [
+        'use-aioha#authentication',
+        'use-aioha#user-management',
+        'use-aioha#onchain-operations',
+        'use-aioha#helpers',
+      ],
+    },
     'use-dhive',
     'extra-utilities',
     // Example for a future "Guides" section


### PR DESCRIPTION
This commit refines the 'Use AIOHA' documentation as per your feedback:

1.  **Content Restructure (`website/docs/use-aioha.md`):**
    - Methods within the 'Use AIOHA' page have been reorganized into four sub-sections: - `Authentication`: Contains `Login With Keychain`, `Login With Hive Auth`, `Login With Plaintext Key`. - `User management`: Contains `Get Current User`, `Logout`, `Switch User`, `Get Other Logins`, `Remove Other Login`. - `Onchain Operations`: Contains `Single Vote`, `Comment`, `Comment With Options`, `Delete Comment`, `Reblog`, `Follow`, `Claim Rewards`. - `Helpers` (new section): Contains `Get QR String`, `Sign Message`, `Sign And Broadcast Tx`, `Add Account Authority`, `Remove Account Authority`.
    - Nested sub-sub-headings under 'Onchain Operations' were removed for a flatter structure under the main sub-sections.

2.  **Sidebar Update (`website/sidebars.js`):**
    - The 'Use AIOHA' item in the sidebar is now a category (collapsible dropdown).
    - The category title itself links to the main `use-aioha.md` page.
    - The dropdown items link directly to the 'Authentication', 'User management', 'Onchain Operations', and 'Helpers' sections within the `use-aioha.md` page using anchors.

These changes improve the organization and navigability of the AIOHA-related documentation.