### PR TITLE
Fix: Correct sidebar link format for anchors in Docusaurus

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -35,10 +35,26 @@ const sidebars = {
         id: 'use-aioha',
       },
       items: [
-        'use-aioha#authentication',
-        'use-aioha#user-management',
-        'use-aioha#onchain-operations',
-        'use-aioha#helpers',
+        {
+          type: 'link',
+          label: 'Authentication',
+          href: '/docs/use-aioha#authentication',
+        },
+        {
+          type: 'link',
+          label: 'User management',
+          href: '/docs/use-aioha#user-management',
+        },
+        {
+          type: 'link',
+          label: 'Onchain Operations',
+          href: '/docs/use-aioha#onchain-operations',
+        },
+        {
+          type: 'link',
+          label: 'Helpers',
+          href: '/docs/use-aioha#helpers',
+        },
       ],
     },
     'use-dhive',


### PR DESCRIPTION
This commit fixes a build error caused by an incorrect format for anchor links in `website/sidebars.js`.

The Docusaurus build was failing with the error:
`These sidebar document ids do not exist: use-aioha#authentication, ...`

This was because string items like `'use-aioha#authentication'` are not recognized as valid document IDs when they contain anchors.

The fix involves changing the items in the 'Use AIOHA' category sidebar from simple strings to `type: 'link'` objects. This provides an explicit `href` for each link, which Docusaurus can correctly process.

For example, `'use-aioha#authentication'` was changed to:
```javascript
{
  type: 'link',
  label: 'Authentication',
  href: '/docs/use-aioha#authentication',
}
```
This change has been applied to all sub-section links within the 'Use AIOHA' sidebar category.