### PR TITLE
Fix: Remove 'Our Contributions' link from sidebar

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -19,7 +19,6 @@ const sidebars = {
   // But we want to create a custom sidebar
   docsSidebar: [
     'intro', // Points to docs/intro.md
-    'our-contributions',
     {
       type: 'category',
       label: 'Getting Started',


### PR DESCRIPTION
This commit removes the 'Our Contributions' page link from the main documentation sidebar (`website/sidebars.js`).

The 'Our Contributions' page is already accessible via a link in the website footer, so this change avoids redundancy in the navigation.