### PR TITLE
feat: Add explicit width and height to homepage feature images

### DIFF
--- a/website/src/components/HomepageFeatures/index.js
+++ b/website/src/components/HomepageFeatures/index.js
@@ -13,8 +13,8 @@ const FeatureList = [
         applications, allowing you to add Hive authentication with minimal setup.
       </>
     ),
-    width: 200,
-    height: 200,
+    width: 272,
+    height: 172,
   },
   {
     title: 'Connect to Hive, Not Complexity',
@@ -25,8 +25,8 @@ const FeatureList = [
         so you can focus on building great user experiences on the Hive blockchain.
       </>
     ),
-    width: 200,
-    height: 200,
+    width: 260,
+    height: 138,
   },
   {
     title: 'Open Source & Community Driven',
@@ -37,8 +37,8 @@ const FeatureList = [
         Contributions are welcome to help it grow and thrive!
       </>
     ),
-    width: 200,
-    height: 200,
+    width: 282,
+    height: 166,
   },
 ];
 

--- a/website/src/components/HomepageFeatures/index.js
+++ b/website/src/components/HomepageFeatures/index.js
@@ -13,6 +13,8 @@ const FeatureList = [
         applications, allowing you to add Hive authentication with minimal setup.
       </>
     ),
+    width: 200,
+    height: 200,
   },
   {
     title: 'Connect to Hive, Not Complexity',
@@ -23,6 +25,8 @@ const FeatureList = [
         so you can focus on building great user experiences on the Hive blockchain.
       </>
     ),
+    width: 200,
+    height: 200,
   },
   {
     title: 'Open Source & Community Driven',
@@ -33,14 +37,16 @@ const FeatureList = [
         Contributions are welcome to help it grow and thrive!
       </>
     ),
+    width: 200,
+    height: 200,
   },
 ];
 
-function Feature({imgSrc, title, description}) {
+function Feature({imgSrc, title, description, width, height}) {
   return (
     <div className={clsx('col col--4')}>
       <div className="text--center">
-        <img src={useBaseUrl(imgSrc)} alt={title} className={styles.featureSvg} />
+        <img src={useBaseUrl(imgSrc)} alt={title} className={styles.featureSvg} width={width} height={height} />
       </div>
       <div className="text--center padding-horiz--md">
         <Heading as="h3">{title}</Heading>


### PR DESCRIPTION
I modified `website/src/components/HomepageFeatures/index.js` to:
- Add `width` and `height` properties (defaulting to 200x200) to each object in the `FeatureList` array.
- Update the `Feature` component to accept and utilize these `width` and `height` props for the `<img>` tag.

This addresses the issue of specifying image dimensions directly in the feature list, which can help prevent layout shift and improve rendering performance.