### PR TITLE
Fix: Update Docusaurus links to use correct page slugs

### DIFF
--- a/website/docs/threespeak/current-account.md
+++ b/website/docs/threespeak/current-account.md
@@ -112,6 +112,6 @@ Navigator.push(
 
 ## See Also
 
-- [VideoUploadScreen](/threespeak/video-upload.md)
-- [VideoPlayerScreen](/threespeak/video-player.md)
-- [ThreeSpeakVideoFeed](/threespeak/video-feed.md)
+- [VideoUploadScreen](/video-upload)
+- [VideoPlayerScreen](/video-player)
+- [ThreeSpeakVideoFeed](/video-feed)

--- a/website/docs/threespeak/login.md
+++ b/website/docs/threespeak/login.md
@@ -121,8 +121,8 @@ Leverages `LoginScreen` to support:
 
 ## See Also
 
-- [VideoUploadScreen](/docs/threespeak/video-upload) - For uploading videos after logging in.
-- [ThreeSpeakCurrentUserAccount](/docs/threespeak/current-account) - For managing the logged-in user's 3Speak content.
-- [ThreeSpeakVideoFeed](/docs/threespeak/video-feed) - For displaying various video feeds.
+- [VideoUploadScreen](/video-upload) - For uploading videos after logging in.
+- [ThreeSpeakCurrentUserAccount](/current-account) - For managing the logged-in user's 3Speak content.
+- [ThreeSpeakVideoFeed](/video-feed) - For displaying various video feeds.
 - `LoginScreen` (from `hive_flutter_kit`) - The base widget used for Hive authentication.
 

--- a/website/docs/threespeak/trending-tags.md
+++ b/website/docs/threespeak/trending-tags.md
@@ -101,6 +101,6 @@ Currently, the `ThreeSpeakTrendingTags` widget does not expose direct parameters
 
 ## See Also
 
--   [ThreeSpeakVideoFeed](/docs/threespeak/video-feed) - Can be used in conjunction with `ThreeSpeakTrendingTags` to display videos for a selected tag using `feedType: ThreeSpeakVideoFeedType.trendingTagFeed`.
+-   [ThreeSpeakVideoFeed](/video-feed) - Can be used in conjunction with `ThreeSpeakTrendingTags` to display videos for a selected tag using `feedType: ThreeSpeakVideoFeedType.trendingTagFeed`.
 -   `GQLCommunicator` (internal) - Used for API communication.
 -   `TrendingTagResponseDataTrendingTag` (internal model) - The data structure for individual tag items.

--- a/website/docs/threespeak/video-feed.md
+++ b/website/docs/threespeak/video-feed.md
@@ -230,6 +230,6 @@ onTapVideoItem: (tappedItem) {
 
 ---
 ## See Also
-- [VideoPlayerScreen](/docs/threespeak/video-player) - For playing individual videos from the feed.
-- [ThreeSpeakTrendingTags](/docs/threespeak/trending-tags) - For displaying a list of trending tags, which can then be used to filter this video feed (using `feedType: ThreeSpeakVideoFeedType.trendingTagFeed`).
+- [VideoPlayerScreen](/video-player) - For playing individual videos from the feed.
+- [ThreeSpeakTrendingTags](/trending-tags) - For displaying a list of trending tags, which can then be used to filter this video feed (using `feedType: ThreeSpeakVideoFeedType.trendingTagFeed`).
 - `VideoCard` widget (internal component) - The UI element used to display each video in the feed.

--- a/website/docs/threespeak/video-player.md
+++ b/website/docs/threespeak/video-player.md
@@ -188,7 +188,7 @@ Navigator.push(
 ---
 
 ## See Also
-- [ThreeSpeakVideoFeed](/docs/threespeak/video-feed) - Often used for the `videoFeed` parameter or to navigate to this screen.
+- [ThreeSpeakVideoFeed](/video-feed) - Often used for the `videoFeed` parameter or to navigate to this screen.
 - `GQLFeedItem` (model from `hive_flutter_kit`) - The data structure for video items.
 - `Discussion` (model from `hive_flutter_kit`) - The data structure for Hive post details.
 - `chewie` and `video_player` Flutter packages.

--- a/website/docs/threespeak/video-upload.md
+++ b/website/docs/threespeak/video-upload.md
@@ -132,9 +132,9 @@ Navigator.push(
 
 ## See Also
 
--   [ThreeSpeakLoginScreen](/docs/threespeak/login) - For obtaining the `token` required by `VideoUploadScreen`.
--   [ThreeSpeakVideoFeed](/docs/threespeak/video-feed) - For displaying video feeds.
--   [VideoPlayerScreen](/docs/threespeak/video-player) - For playing uploaded videos.
+-   [ThreeSpeakLoginScreen](/login) - For obtaining the `token` required by `VideoUploadScreen`.
+-   [ThreeSpeakVideoFeed](/video-feed) - For displaying video feeds.
+-   [VideoPlayerScreen](/video-player) - For playing uploaded videos.
 -   `another_tus_client` package (for TUS protocol).
 -   `file_picker` package (for picking video files).
 -   `image_picker` package (used in `ThumbnailUploadScreen`).


### PR DESCRIPTION
Corrected internal links within the 3Speak documentation to use the page slugs defined in the frontmatter of the markdown files (e.g., `/login`, `/video-feed`) instead of file paths or incorrect prefixed paths.

This ensures that Docusaurus can correctly resolve these links during the build process, fixing the 'Document Deployment' GitHub Action failures caused by broken links.